### PR TITLE
Make option properties optional

### DIFF
--- a/projects/signal-forms/src/lib/config/defaults.config.ts
+++ b/projects/signal-forms/src/lib/config/defaults.config.ts
@@ -1,0 +1,7 @@
+import { SignalFormOptions } from "../interfaces/signal-forms-options.interface";
+
+export const signalFormOptionsDefaults: SignalFormOptions = {
+    requireTouched: true,
+	defaultState: 'default',
+	errorState: 'error'
+}

--- a/projects/signal-forms/src/lib/signal-forms.module.spec.ts
+++ b/projects/signal-forms/src/lib/signal-forms.module.spec.ts
@@ -7,6 +7,7 @@ import { SignalForm } from "./interfaces/signal-forms.interface"
 import { signalForm } from "./signal-forms.module"
 import { signalFormValid } from "./helpers/signal-form-valid.helper";
 import { signalFormValue } from "./helpers/signal-form-value.helper"
+import { signalFormOptionsDefaults } from "./config/defaults.config"
 
 interface ITestObject {
     field1: string
@@ -57,7 +58,7 @@ describe('signalForms', () => {
     })
 
     it('should require touched by default', () => {
-        expect(form.field3.state().state).toBe("default")
+        expect(form.field3.state().state).toBe(signalFormOptionsDefaults.defaultState)
     })
 
     it('should allow touched to be optional', () => {
@@ -72,6 +73,21 @@ describe('signalForms', () => {
 
     it('should return the validator message', () => {
         expect(customForm.field3.state().message).toBe("Must be after 2024-11-21")
+    })
+
+    it('should allow partial options', () => {
+        let form = signalForm({
+            test: {
+                initialValue: "",
+                validators: [
+                    val => !val ? new Error("Required") : null
+                ]
+            }
+        }, {
+            requireTouched: false
+        })
+        expect(form.test.touched()).toBeFalse()
+        expect(form.test.state().state).toBe(signalFormOptionsDefaults.errorState)
     })
 
     describe('resetSignalForm', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,7 +45,5 @@ export class AppComponent {
   $formErrors = signalFormErrors(this.form)
   $formValid = signalFormValid(this.form)
 
-  resetForm() {
-    resetSignalForm(this.form)
-  }
+  resetForm = () => resetSignalForm(this.form)
 }


### PR DESCRIPTION
User doesn't need to provide all options to the signalForm function when customizing. If an option is not provided the default value will be used.