### PR TITLE
Add signalFormGroup

### DIFF
--- a/projects/signal-forms/src/lib/helpers/signal-form-errors.helper.ts
+++ b/projects/signal-forms/src/lib/helpers/signal-form-errors.helper.ts
@@ -1,19 +1,21 @@
 import { computed } from "@angular/core";
 import { SignalForm } from "../interfaces/signal-forms.interface";
 
-export function signalFormErrors<T>(form: SignalForm<T>) {
-    return computed<string[]>(() => {
-        let errors: string[] = []
-        for (let key in form) {
-            let field = form[key]
-            let validatorList = field.validators
-            for (let validator of validatorList) {
-                let result = validator(field.currentValue(), form)
-                if (result) {
-                    errors.push(`${key}: ${result.message}`)
-                }
+export function signalFormErrors<T>(signalForm: SignalForm<T>) {
+    return computed<string[]>(() => getSignalFormErrors(signalForm))
+}
+
+export function getSignalFormErrors<T>(signalForm: SignalForm<T>) {
+    let errors: string[] = []
+    for (let key in signalForm) {
+        let field = signalForm[key]
+        let validatorList = field.validators
+        for (let validator of validatorList) {
+            let result = validator(field.currentValue(), signalForm)
+            if (result) {
+                errors.push(`${key}: ${result.message}`)
             }
         }
-        return errors
-    })
+    }
+    return errors
 }

--- a/projects/signal-forms/src/lib/helpers/signal-form-valid.helper.ts
+++ b/projects/signal-forms/src/lib/helpers/signal-form-valid.helper.ts
@@ -7,13 +7,15 @@ import { SignalForm } from "../interfaces/signal-forms.interface"
  * @returns a boolean Signal representing the form validity
  */
 export function signalFormValid<T>(signalForm: SignalForm<T>): Signal<boolean> {
-	return computed(() => {
-		for (let key in signalForm) {
-			let field = signalForm[key]
-			if (!field.valid()) {
-				return false
-			}
+	return computed(() => getSignalFormValid(signalForm))
+}
+
+export function getSignalFormValid<T>(signalForm: SignalForm<T>) {
+	for (let key in signalForm) {
+		let field = signalForm[key]
+		if (!field.valid()) {
+			return false
 		}
-		return true
-	})
+	}
+	return true
 }

--- a/projects/signal-forms/src/lib/helpers/signal-form-value.helper.ts
+++ b/projects/signal-forms/src/lib/helpers/signal-form-value.helper.ts
@@ -2,11 +2,13 @@ import { computed } from "@angular/core"
 import { SignalForm } from "../interfaces/signal-forms.interface"
 
 export function signalFormValue<T>(signalForm: SignalForm<T>) {
-	return computed(() => {
-		let output: Record<string | number | symbol, unknown> = {}
-		for (let key in signalForm) {
-			output[key] = signalForm[key].currentValue()
-		}
-		return output as T
-	})
+	return computed(() => getSignalFormValue(signalForm))
+}
+
+export function getSignalFormValue<T>(signalForm: SignalForm<T>) {
+	let output: Record<string | number | symbol, unknown> = {}
+	for (let key in signalForm) {
+		output[key] = signalForm[key].currentValue()
+	}
+	return output as T
 }

--- a/projects/signal-forms/src/lib/interfaces/signal-form-group.interface.ts
+++ b/projects/signal-forms/src/lib/interfaces/signal-form-group.interface.ts
@@ -1,0 +1,11 @@
+import { Signal, WritableSignal } from "@angular/core";
+import { SignalForm } from "./signal-forms.interface";
+
+export type SignalFormGroup<T> = {
+    data: WritableSignal<Array<SignalForm<T>>>
+    addItem(): void
+    removeItem(index: number): void
+    value(): Signal<Array<T>>
+    valid(): Signal<boolean>
+    errors(): Signal<Array<string>>
+}

--- a/projects/signal-forms/src/lib/interfaces/signal-form-group.interface.ts
+++ b/projects/signal-forms/src/lib/interfaces/signal-form-group.interface.ts
@@ -3,7 +3,7 @@ import { SignalForm } from "./signal-forms.interface";
 
 export type SignalFormGroup<T> = {
     data: WritableSignal<Array<SignalForm<T>>>
-    addItem(): void
+    addItem(value?: Partial<T>): void
     removeItem(index: number): void
     value(): Signal<Array<T>>
     valid(): Signal<boolean>

--- a/projects/signal-forms/src/lib/signal-form-group.module.ts
+++ b/projects/signal-forms/src/lib/signal-form-group.module.ts
@@ -1,12 +1,12 @@
 import { computed, signal } from "@angular/core";
 import { getSignalFormErrors } from "./helpers/signal-form-errors.helper";
 import { getSignalFormValid } from "./helpers/signal-form-valid.helper";
+import { getSignalFormValue } from "./helpers/signal-form-value.helper";
 import { SignalFormGroup } from "./interfaces/signal-form-group.interface";
 import { SignalFormDefinition } from "./interfaces/signal-forms-definition.interface";
 import { SignalFormOptions } from "./interfaces/signal-forms-options.interface";
 import { SignalForm } from "./interfaces/signal-forms.interface";
-import { signalForm as form } from "./signal-forms.module";
-import { getSignalFormValue } from "./helpers/signal-form-value.helper";
+import { signalForm } from "./signal-forms.module";
 
 export function signalFormGroup<T>(
     initialValue: SignalFormDefinition<T>,
@@ -14,11 +14,13 @@ export function signalFormGroup<T>(
 ): SignalFormGroup<T> {
     return {
         data: signal<Array<SignalForm<T>>>([]),
-        addItem() {
+        addItem(value?: Partial<T>) {
             this.data.update(current => {
+                let newSignalForm = signalForm(initialValue, options)
+                setExistingValues(newSignalForm, value)
                 return [
                     ...current,
-                    form<T>(initialValue, options)
+                    newSignalForm
                 ]
             })
         },
@@ -37,5 +39,17 @@ export function signalFormGroup<T>(
         errors() {
             return computed(() => this.data().map(form => getSignalFormErrors(form)).flat())
         },
+    }
+}
+
+function setExistingValues<T>(form: SignalForm<T>, value?: Partial<T>) {
+    if (value) {
+        for (let key in form) {
+            let fieldValue = value[key]
+            if (fieldValue) {
+                form[key].currentValue.set(fieldValue)
+                form[key].touched.set(true)
+            }
+        }
     }
 }

--- a/projects/signal-forms/src/lib/signal-form-group.module.ts
+++ b/projects/signal-forms/src/lib/signal-form-group.module.ts
@@ -1,0 +1,41 @@
+import { computed, signal } from "@angular/core";
+import { getSignalFormErrors } from "./helpers/signal-form-errors.helper";
+import { getSignalFormValid } from "./helpers/signal-form-valid.helper";
+import { SignalFormGroup } from "./interfaces/signal-form-group.interface";
+import { SignalFormDefinition } from "./interfaces/signal-forms-definition.interface";
+import { SignalFormOptions } from "./interfaces/signal-forms-options.interface";
+import { SignalForm } from "./interfaces/signal-forms.interface";
+import { signalForm as form } from "./signal-forms.module";
+import { getSignalFormValue } from "./helpers/signal-form-value.helper";
+
+export function signalFormGroup<T>(
+    initialValue: SignalFormDefinition<T>,
+    options?: SignalFormOptions
+): SignalFormGroup<T> {
+    return {
+        data: signal<Array<SignalForm<T>>>([]),
+        addItem() {
+            this.data.update(current => {
+                return [
+                    ...current,
+                    form<T>(initialValue, options)
+                ]
+            })
+        },
+        removeItem(index: number) {
+            this.data.update(current => {
+                current.splice(index, 1)
+                return [...current]
+            })
+        },
+        value() {
+            return computed(() => this.data().map(form => getSignalFormValue(form)))
+        },
+        valid() {
+            return computed(() => this.data().every(form => getSignalFormValid(form)))
+        },
+        errors() {
+            return computed(() => this.data().map(form => getSignalFormErrors(form)).flat())
+        },
+    }
+}

--- a/projects/signal-forms/src/lib/signal-forms.module.spec.ts
+++ b/projects/signal-forms/src/lib/signal-forms.module.spec.ts
@@ -9,6 +9,8 @@ import { signalFormValid } from "./helpers/signal-form-valid.helper";
 import { signalFormValue } from "./helpers/signal-form-value.helper"
 import { signalFormOptionsDefaults } from "./config/defaults.config"
 import { signalFormSetTouched } from "./helpers/signal-form-set-touched.helper"
+import { signalFormGroup } from "./signal-form-group.module"
+import { SignalFormGroup } from "./interfaces/signal-form-group.interface"
 
 interface ITestObject {
     field1: string
@@ -17,37 +19,38 @@ interface ITestObject {
     field3: Date
 }
 
-describe('signalForms', () => {
-    let testObject: SignalFormDefinition<ITestObject> = {
-        field1: {
-            initialValue: "Placeholder"
-        },
-        field1Child: {
-            initialValue: "",
-            validators: [
-                (val, form) => !val && form.field1.currentValue() ? new Error("Required if field1 given") : null
-            ]
-        },
-        field2: {
-            initialValue: 0,
-            validators: [
-                val => !val ? new Error("Required") : null
-            ]
-        },
-        field3: {
-            initialValue: new Date('2024-11-20T09:30:11'),
-            validators: [
-                val => val.toISOString().slice(0,10) < '2024-11-21' ? new Error("Must be after 2024-11-21") : null,
-                val => val.getHours() != 0 ? new Error("Should be midnight") : null
-            ]
-        }
+let signalFormDefinition: SignalFormDefinition<ITestObject> = {
+    field1: {
+        initialValue: "Placeholder"
+    },
+    field1Child: {
+        initialValue: "",
+        validators: [
+            (val, form) => !val && form.field1.currentValue() ? new Error("Required if field1 given") : null
+        ]
+    },
+    field2: {
+        initialValue: 0,
+        validators: [
+            val => !val ? new Error("Required") : null
+        ]
+    },
+    field3: {
+        initialValue: new Date('2024-11-20T09:30:11'),
+        validators: [
+            val => val.toISOString().slice(0,10) < '2024-11-21' ? new Error("Must be after 2024-11-21") : null,
+            val => val.getHours() != 0 ? new Error("Should be midnight") : null
+        ]
     }
+}
+
+describe('signalForms', () => {
     let form: SignalForm<ITestObject>
     let customForm: SignalForm<ITestObject>
 
     beforeEach(() => {
-        form = signalForm(testObject)
-        customForm = signalForm(testObject, {
+        form = signalForm(signalFormDefinition)
+        customForm = signalForm(signalFormDefinition, {
             requireTouched: false,
             errorState: 'myError',
             defaultState: 'myDefault'
@@ -150,7 +153,7 @@ describe('signalForms', () => {
     describe('signalFormValue', () => {
         it('should return an object of T in SignalForm<T>', () => {
             let $value = signalFormValue(form)
-            let originalObjectKeys = Object.keys(testObject).sort()
+            let originalObjectKeys = Object.keys(signalFormDefinition).sort()
             let keys = Object.keys($value()).sort()
             expect(keys).toEqual(originalObjectKeys)
             expect($value().field1).toBe('Placeholder')
@@ -163,6 +166,67 @@ describe('signalForms', () => {
             Object.entries(form).forEach(([key, field]) => {
                 expect(field.touched()).withContext(key).toBeTrue()
             })
+        })
+    })
+})
+
+describe('signalFormGroup', () => {
+    let formGroup: SignalFormGroup<ITestObject>
+
+    beforeEach(() => {
+        formGroup = signalFormGroup(signalFormDefinition)
+        formGroup.addItem()
+    })
+
+    describe('.addItem()', () => {
+        it('should allow adding an item', () => {
+            formGroup.addItem()
+            expect(formGroup.data().length).withContext('signalFormGroup.length').toBe(2)
+        })
+    })
+
+    describe('.removeItem()', () => {
+        it('should allow removing an item by index', () => {
+            formGroup.addItem()
+            formGroup.data()[1].field1.currentValue.set("Updated")
+            formGroup.removeItem(0)
+            expect(formGroup.data().length).withContext('signalFormGroup.length').toBe(1)
+            expect(formGroup.data()[0].field1.currentValue()).withContext('last form in group value').toBe("Updated")
+        })
+    })
+
+    describe('.valid()', () => {
+        it('should return a signal validating all forms', () => {
+            let form0 = formGroup.data()[0]
+            let today = new Date()
+            today.setHours(0,0,0,0)
+            form0.field1.currentValue.set("Valid")
+            form0.field1Child.currentValue.set("Also Valid")
+            form0.field2.currentValue.set(1)
+            form0.field3.currentValue.set(today)
+            expect(formGroup.valid()()).withContext('form group with single valid item').toBeTrue()
+            formGroup.addItem()
+            expect(formGroup.valid()()).withContext('form group after adding invalid item').toBeFalse()
+        })
+    })
+
+    describe('.errors()', () => {
+        it('should return a signal containing an array of errors', () => {
+            let $errors = formGroup.errors()
+            formGroup.addItem()
+            expect($errors()).toBeInstanceOf(Array)
+            expect($errors().length).toBe(8)
+            let field1ChildError = 'field1Child: Required if field1 given'
+            expect($errors()[0]).toBe(field1ChildError)
+            expect($errors()[4]).toBe(field1ChildError)
+        })
+    })
+
+    describe('.value()', () => {
+        it('should return a signal containing an array of T', () => {
+            let formValue = formGroup.value()()
+            expect(formValue).toBeInstanceOf(Array)
+            expect(formValue[0].field1).toBe('Placeholder')
         })
     })
 })

--- a/projects/signal-forms/src/lib/signal-forms.module.spec.ts
+++ b/projects/signal-forms/src/lib/signal-forms.module.spec.ts
@@ -179,9 +179,17 @@ describe('signalFormGroup', () => {
     })
 
     describe('.addItem()', () => {
-        it('should allow adding an item', () => {
+        it('should allow adding a new item', () => {
             formGroup.addItem()
             expect(formGroup.data().length).withContext('signalFormGroup.length').toBe(2)
+        })
+
+        it('should allow adding an existing item', () => {
+            let field1Value = "Existing DB Value"
+            formGroup.addItem({
+                field1: field1Value
+            })
+            expect(formGroup.data()[1].field1.currentValue()).toBe(field1Value)
         })
     })
 

--- a/projects/signal-forms/src/public-api.ts
+++ b/projects/signal-forms/src/public-api.ts
@@ -2,13 +2,14 @@
  * Public API Surface of signal-forms
  */
 
-export * from './lib/signal-forms.module'
+export {signalForm} from './lib/signal-forms.module'
+export {signalFormGroup} from './lib/signal-form-group.module'
 
-export * from './lib/helpers/signal-form-valid.helper'
-export * from './lib/helpers/reset-signal-form.helper'
-export * from './lib/helpers/signal-form-value.helper'
-export * from './lib/helpers/signal-form-set-touched.helper'
+export {signalFormValid} from './lib/helpers/signal-form-valid.helper'
+export {resetSignalForm} from './lib/helpers/reset-signal-form.helper'
+export {signalFormValue} from './lib/helpers/signal-form-value.helper'
+export {signalFormSetTouched} from './lib/helpers/signal-form-set-touched.helper'
 
-export * from './lib/interfaces/signal-forms.interface'
-export * from './lib/interfaces/signal-forms-options.interface'
-export * from './lib/interfaces/signal-forms-definition.interface'
+export {SignalForm} from './lib/interfaces/signal-forms.interface'
+export {SignalFormOptions} from './lib/interfaces/signal-forms-options.interface'
+export {SignalFormDefinition} from './lib/interfaces/signal-forms-definition.interface'

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -61,12 +61,6 @@
     Current Value: {{$formValue() | json}}
     <br>
     All Errors: {{$formErrors() | json}}
-    <br><br>
-    <button (click)="resetForm()">Reset Form</button>
-    <br>
-    <button (click)="submit()">Submit</button>
-    <br>
-    <button (click)="submit()" [disabled]="!$formValid()">Submit If Valid</button>
 </div>
 <br><br>
 <div>
@@ -113,4 +107,10 @@
     Complete Errors: {{$completeErrors() | json}}
     <br>
     Complete Value: {{$completeValue() | json}}
+    <br><br>
+    <button (click)="resetForm()">Reset Form</button>
+    <br>
+    <button (click)="submit()">Submit</button>
+    <br>
+    <button (click)="submit()" [disabled]="!$completeValid()">Submit If Valid</button>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -68,3 +68,49 @@
     <br>
     <button (click)="submit()" [disabled]="!$formValid()">Submit If Valid</button>
 </div>
+<br><br>
+<div>
+    <table>
+        <thead>
+            <th>ID</th>
+            <th>Name</th>
+            <th></th>
+        </thead>
+        <tbody>
+            @for (item of $tableData.data(); track $index) {
+                <tr>
+                    <td>
+                        <input type="text" [(ngModel)]="item.id.currentValue">
+                    </td>
+                    <td>
+                        <input type="text" [(ngModel)]="item.name.currentValue">
+                    </td>
+                    <td>
+                        <button (click)="$tableData.removeItem($index)">Delete</button>
+                    </td>
+                </tr>
+            }
+            <tr>
+                <td colspan="3">
+                    <button (click)="$tableData.addItem()">Add</button>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<br><br>
+<div>
+    Table Valid: {{$tableValid()}}
+    <br>
+    Table Errors: {{$tableErrors() | json}}
+    <br>
+    Table Value: {{$tableValue() | json}}
+</div>
+<br><br>
+<div>
+    Complete Valid: {{$completeValid()}}
+    <br>
+    Complete Errors: {{$completeErrors() | json}}
+    <br>
+    Complete Value: {{$completeValue() | json}}
+</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -81,11 +81,17 @@ export class AppComponent {
     ]
   }))
 
-  resetForm = () => resetSignalForm(this.form)
+  resetForm = () => {
+    resetSignalForm(this.form)
+    this.$tableData.data.set([])
+  }
   
   submit() {
     signalFormSetTouched(this.form)
-    if (!this.$formValid()) {
+    this.$tableData.data().forEach(tableForm => {
+      signalFormSetTouched(tableForm)
+    })
+    if (!this.$completeValid()) {
       return
     }
     // submit to server

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { signalForm, signalFormValue, signalFormValid, resetSignalForm, signalFormSetTouched } from '../../projects/signal-forms/src/public-api';
+import { Component, computed } from '@angular/core';
+import { signalForm, signalFormValue, signalFormValid, resetSignalForm, signalFormSetTouched, signalFormGroup } from '../../projects/signal-forms/src/public-api';
 import { FormsModule } from '@angular/forms';
 import { signalFormErrors } from '../../projects/signal-forms/src/lib/helpers/signal-form-errors.helper';
 import { CommonModule } from '@angular/common';
@@ -9,6 +9,11 @@ interface DataType {
   field1Child: string
   field2: string
   dateField: string
+}
+
+interface TableItem {
+  id: string
+  name: string
 }
 
 @Component({
@@ -49,6 +54,32 @@ export class AppComponent {
   $formValue = signalFormValue(this.form)
   $formErrors = signalFormErrors(this.form)
   $formValid = signalFormValid(this.form)
+
+  $tableData = signalFormGroup<TableItem>({
+    id: {
+      initialValue: '',
+      validators: [
+        val => !val ? new Error('Required') : null
+      ]
+    },
+    name: {
+      initialValue: '',
+      validators: undefined
+    }
+  })
+
+  $tableValid = this.$tableData.valid()
+  $tableErrors = this.$tableData.errors()
+  $tableValue = this.$tableData.value()
+
+  $completeValid = computed(() => this.$formValid() && this.$tableValid())
+  $completeErrors = computed(() => [...this.$formErrors(), ...this.$tableErrors()])
+  $completeValue = computed(() => ({
+    ...this.$formValue(),
+    table: [
+      ...this.$tableValue()
+    ]
+  }))
 
   resetForm = () => resetSignalForm(this.form)
   


### PR DESCRIPTION
Added a SignalFormGroup module, which wraps a signal of an array of SignalForm's, to be used in, for example, a table setup.